### PR TITLE
MARS-9: Display dates for the Kennedy Space Center on homepage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,8 @@
 <body>
     <h1 id="intro-text">Beep-bop-boop... Welcome to the Mars Rover!</h1>
     <p id="earth-date">Earth date: </p>
+    <p id="kennedy-offset">You are: </p>
+    <p id="kennedy-time">Kennedy Space Center time: </p>
     <div class="image-container">
         <img id="intro-image" src="mars-rover.jpg" alt="Mars Rover"></img>
     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -8,8 +8,10 @@
 </head>
 <body>
     <h1 id="intro-text">Beep-bop-boop... Welcome to the Mars Rover!</h1>
-    <p id="earth-date">Earth date: </p>
-    <p id="kennedy-offset">You are: </p>
+    <div id="date-container">
+        <p id="earth-date">Earth date: </p>
+        <p id="kennedy-offset">(You are: </p>
+    </div>
     <p id="kennedy-time">Kennedy Space Center time: </p>
     <div class="image-container">
         <img id="intro-image" src="mars-rover.jpg" alt="Mars Rover"></img>

--- a/public/script.js
+++ b/public/script.js
@@ -28,10 +28,10 @@ function displayOffsetTimeToKennedySpaceCenter() {
   const kennedyOffset = document.createTextNode(timeBetweenKennedyAndUtc);
   kennedyOffsetTime.appendChild(kennedyOffset);
   const aheadOfKennedy = document.createTextNode(
-    " hours ahead of Kennedy Space Center"
+    " hours ahead of Kennedy Space Center)"
   );
   const behindKennedy = document.createTextNode(
-    " hours behind of Kennedy Space Center"
+    " hours behind of Kennedy Space Center)"
   );
 
   if (timeBetweenKennedyAndUtc > 0) {

--- a/public/script.js
+++ b/public/script.js
@@ -21,18 +21,17 @@ displayKennedySpaceCenterTime();
 function displayOffsetTimeToKennedySpaceCenter() {
   const utcOffsetTimeInHours = earthDate.getTimezoneOffset() / 60;
   const timeBetweenKennedyAndUtc = utcOffsetTimeInHours + 5;
-  const aheadOfKennedy = document.createTextNode(
-    `${timeBetweenKennedyAndUtc} hours ahead of Kennedy Space Center)`
-  );
-  const behindKennedy = document.createTextNode(
-    `${timeBetweenKennedyAndUtc} hours behind of Kennedy Space Center)`
+  const isAhead = timeBetweenKennedyAndUtc > 0;
+
+  const timeBetweenKennedyandUtcText = document.createTextNode(
+    `${timeBetweenKennedyAndUtc} hours ${
+      isAhead ? "ahead" : "behind"
+    } of Kennedy Space Center)`
   );
 
-  if (timeBetweenKennedyAndUtc > 0) {
-    document.querySelector("#kennedy-offset").appendChild(aheadOfKennedy);
-  } else {
-    document.querySelector("#kennedy-offset").appendChild(behindKennedy);
-  }
+  document
+    .querySelector("#kennedy-offset")
+    .appendChild(timeBetweenKennedyandUtcText);
 }
 
 displayOffsetTimeToKennedySpaceCenter();

--- a/public/script.js
+++ b/public/script.js
@@ -1,5 +1,44 @@
-const earthDateParagraph = document.querySelector("#earth-date");
 const earthDate = new Date();
-const dateText = document.createTextNode(earthDate.toLocaleString());
 
-earthDateParagraph.appendChild(dateText);
+function displayCurrentEarthDate() {
+  const earthDateParagraph = document.querySelector("#earth-date");
+  const dateText = document.createTextNode(earthDate.toLocaleString());
+
+  earthDateParagraph.appendChild(dateText);
+}
+
+displayCurrentEarthDate();
+
+function displayKennedySpaceCenterTime() {
+  const kennedyTimeParagraph = document.querySelector("#kennedy-time");
+  const kennedyTime = earthDate.toLocaleTimeString("en-US", {
+    timeZone: "America/New_York",
+  });
+  const kennedyTimeText = document.createTextNode(kennedyTime.split(" ")[0]);
+
+  kennedyTimeParagraph.appendChild(kennedyTimeText);
+}
+
+displayKennedySpaceCenterTime();
+
+function displayOffsetTimeToKennedySpaceCenter() {
+  const kennedyOffsetTime = document.querySelector("#kennedy-offset");
+  const utcOffsetTimeInHours = earthDate.getTimezoneOffset() / 60;
+  const timeBetweenKennedyAndUtc = utcOffsetTimeInHours + 5;
+  const kennedyOffset = document.createTextNode(timeBetweenKennedyAndUtc);
+  kennedyOffsetTime.appendChild(kennedyOffset);
+  const aheadOfKennedy = document.createTextNode(
+    " hours ahead of Kennedy Space Center"
+  );
+  const behindKennedy = document.createTextNode(
+    " hours ahead of Kennedy Space Center"
+  );
+
+  if (timeBetweenKennedyAndUtc > 0) {
+    kennedyOffsetTime.appendChild(aheadOfKennedy);
+  } else {
+    kennedyOffsetTime.appendChild(behindKennedy);
+  }
+}
+
+displayOffsetTimeToKennedySpaceCenter();

--- a/public/script.js
+++ b/public/script.js
@@ -11,10 +11,10 @@ displayCurrentEarthDate();
 
 function displayKennedySpaceCenterTime() {
   const kennedyTimeParagraph = document.querySelector("#kennedy-time");
-  const kennedyTime = earthDate.toLocaleTimeString("en-US", {
+  const kennedyTime = earthDate.toLocaleTimeString(undefined, {
     timeZone: "America/New_York",
   });
-  const kennedyTimeText = document.createTextNode(kennedyTime.split(" ")[0]);
+  const kennedyTimeText = document.createTextNode(kennedyTime);
 
   kennedyTimeParagraph.appendChild(kennedyTimeText);
 }
@@ -31,7 +31,7 @@ function displayOffsetTimeToKennedySpaceCenter() {
     " hours ahead of Kennedy Space Center"
   );
   const behindKennedy = document.createTextNode(
-    " hours ahead of Kennedy Space Center"
+    " hours behind of Kennedy Space Center"
   );
 
   if (timeBetweenKennedyAndUtc > 0) {

--- a/public/script.js
+++ b/public/script.js
@@ -1,43 +1,37 @@
 const earthDate = new Date();
 
 function displayCurrentEarthDate() {
-  const earthDateParagraph = document.querySelector("#earth-date");
   const dateText = document.createTextNode(earthDate.toLocaleString());
-
-  earthDateParagraph.appendChild(dateText);
+  document.querySelector("#earth-date").appendChild(dateText);
 }
 
 displayCurrentEarthDate();
 
 function displayKennedySpaceCenterTime() {
-  const kennedyTimeParagraph = document.querySelector("#kennedy-time");
   const kennedyTime = earthDate.toLocaleTimeString(undefined, {
     timeZone: "America/New_York",
   });
   const kennedyTimeText = document.createTextNode(kennedyTime);
 
-  kennedyTimeParagraph.appendChild(kennedyTimeText);
+  document.querySelector("#kennedy-time").appendChild(kennedyTimeText);
 }
 
 displayKennedySpaceCenterTime();
 
 function displayOffsetTimeToKennedySpaceCenter() {
-  const kennedyOffsetTime = document.querySelector("#kennedy-offset");
   const utcOffsetTimeInHours = earthDate.getTimezoneOffset() / 60;
   const timeBetweenKennedyAndUtc = utcOffsetTimeInHours + 5;
-  const kennedyOffset = document.createTextNode(timeBetweenKennedyAndUtc);
-  kennedyOffsetTime.appendChild(kennedyOffset);
   const aheadOfKennedy = document.createTextNode(
-    " hours ahead of Kennedy Space Center)"
+    `${timeBetweenKennedyAndUtc} hours ahead of Kennedy Space Center)`
   );
   const behindKennedy = document.createTextNode(
-    " hours behind of Kennedy Space Center)"
+    `${timeBetweenKennedyAndUtc} hours behind of Kennedy Space Center)`
   );
 
   if (timeBetweenKennedyAndUtc > 0) {
-    kennedyOffsetTime.appendChild(aheadOfKennedy);
+    document.querySelector("#kennedy-offset").appendChild(aheadOfKennedy);
   } else {
-    kennedyOffsetTime.appendChild(behindKennedy);
+    document.querySelector("#kennedy-offset").appendChild(behindKennedy);
   }
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -30,10 +30,17 @@ body {
   text-align: center;
 }
 
+#date-container {
+  height: 20px;
+  display: flex;
+  justify-content: center;
+}
+
 #kennedy-time {
   text-align: center;
 }
 
 #kennedy-offset {
   text-align: center;
+  color: rgb(150, 150, 150);
 }

--- a/public/style.css
+++ b/public/style.css
@@ -29,3 +29,11 @@ body {
 #earth-date {
   text-align: center;
 }
+
+#kennedy-time {
+  text-align: center;
+}
+
+#kennedy-offset {
+  text-align: center;
+}


### PR DESCRIPTION
**Changes**
- Display dates for the Kennedy Space Center on homepage
- Display the time zone offset (in hours) of the user's time zone compared to the Kennedy Space Center.

<img width="1669" alt="Screenshot 2020-11-13 at 09 00 04" src="https://user-images.githubusercontent.com/32392044/99049528-dbe90f80-258e-11eb-9acf-2634574e6a3e.png">
